### PR TITLE
Use UNPKG instead of RawGit due RawGit shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bower install boss-validator
 
 #### CDN
 ```html
-<script src="https://cdn.rawgit.com/cezarlz/boss/master/dist/js/boss.min.js"></script>
+<script src="https://unpkg.com/boss-validator/dist/js/boss.min.js"></script>
 ```
 
 ## Validators


### PR DESCRIPTION
As the title implies, consider using UNPKG, RawGit will soon shut down.

Read more here: https://rawgit.com